### PR TITLE
Always monitor L2 distance during training.

### DIFF
--- a/learn2track/factories.py
+++ b/learn2track/factories.py
@@ -132,7 +132,7 @@ def loss_factory(hyperparams, model, dataset, loss_type=None):
         # return L2DistancePlusBinaryCrossEntropy(model, dataset, normalize_output=hyperparams["normalize"])
 
     elif hyperparams['model'] == 'gru_regression':
-        if loss_type is not None:
+        if loss_type is not None and not loss_type == 'l2_distance':
             raise ValueError("loss_type not available for gru_regression: {}".format(loss_type))
 
         from learn2track.models.gru_regression import L2DistanceForSequences
@@ -160,10 +160,14 @@ def loss_factory(hyperparams, model, dataset, loss_type=None):
             return MultivariateGaussianMixtureNLL(model, dataset)
         else:
             raise ValueError("Unrecognized loss_type: {}".format(loss_type))
+
     elif hyperparams['model'] == 'ffnn_regression':
         if loss_type == 'expected_value':
             from learn2track.models.ffnn_regression import UndirectedL2Distance
             return UndirectedL2Distance(model, dataset, hyperparams['normalize'])
+        elif loss_type == 'l2_distance':
+            from learn2track.models.ffnn_regression import L2Distance
+            return L2Distance(model, dataset, hyperparams['normalize'])
         else:
             from learn2track.models.ffnn_regression import CosineSquaredLoss
             return CosineSquaredLoss(model, dataset, normalize_output=hyperparams['normalize'])

--- a/learn2track/factories.py
+++ b/learn2track/factories.py
@@ -132,7 +132,7 @@ def loss_factory(hyperparams, model, dataset, loss_type=None):
         # return L2DistancePlusBinaryCrossEntropy(model, dataset, normalize_output=hyperparams["normalize"])
 
     elif hyperparams['model'] == 'gru_regression':
-        if loss_type is not None and not loss_type == 'l2_distance':
+        if loss_type is not None:
             raise ValueError("loss_type not available for gru_regression: {}".format(loss_type))
 
         from learn2track.models.gru_regression import L2DistanceForSequences

--- a/scripts/learn.py
+++ b/scripts/learn.py
@@ -365,6 +365,14 @@ def main():
         valid_error = views.LossView(loss=valid_loss, batch_scheduler=valid_batch_scheduler)
         trainer.append_task(tasks.Print("Validset - Error        : {0:.2f} | {1:.2f}", valid_error.sum, valid_error.mean))
 
+        valid_batch_scheduler2 = batch_scheduler_factory(hyperparams,
+                                                         dataset=validset,
+                                                         train_mode=False)
+
+        valid_l2 = loss_factory(hyperparams, model, validset, loss_type="l2_distance")
+        valid_l2_error = views.LossView(loss=valid_l2, batch_scheduler=valid_batch_scheduler2)
+        trainer.append_task(tasks.Print("Validset - L2           : {0:.2f} | {1:.2f}", valid_l2_error.sum, valid_l2_error.mean))
+
         # HACK: Restore trainset volume manager
         model.volume_manager = trainset_volume_manager
 

--- a/scripts/learn.py
+++ b/scripts/learn.py
@@ -365,13 +365,14 @@ def main():
         valid_error = views.LossView(loss=valid_loss, batch_scheduler=valid_batch_scheduler)
         trainer.append_task(tasks.Print("Validset - Error        : {0:.2f} | {1:.2f}", valid_error.sum, valid_error.mean))
 
-        valid_batch_scheduler2 = batch_scheduler_factory(hyperparams,
-                                                         dataset=validset,
-                                                         train_mode=False)
+        if hyperparams['model'] == 'ffnn_regression':
+            valid_batch_scheduler2 = batch_scheduler_factory(hyperparams,
+                                                             dataset=validset,
+                                                             train_mode=False)
 
-        valid_l2 = loss_factory(hyperparams, model, validset, loss_type="l2_distance")
-        valid_l2_error = views.LossView(loss=valid_l2, batch_scheduler=valid_batch_scheduler2)
-        trainer.append_task(tasks.Print("Validset - L2           : {0:.2f} | {1:.2f}", valid_l2_error.sum, valid_l2_error.mean))
+            valid_l2 = loss_factory(hyperparams, model, validset, loss_type="l2_distance")
+            valid_l2_error = views.LossView(loss=valid_l2, batch_scheduler=valid_batch_scheduler2)
+            trainer.append_task(tasks.Print("Validset - L2           : {0:.2f} | {1:.2f}", valid_l2_error.sum, valid_l2_error.mean))
 
         # HACK: Restore trainset volume manager
         model.volume_manager = trainset_volume_manager


### PR DESCRIPTION
@ppoulin91 What do you think of always displaying the L2 distance so it is easier to compare to the baseline (i.e. always using the previous directions as the prediction directions). 

Note: will probably need some adjustments for the other models (if needed).