### PR TITLE
Added option to pseudo partition streamlines according to their lengths

### DIFF
--- a/learn2track/batch_schedulers.py
+++ b/learn2track/batch_schedulers.py
@@ -55,7 +55,7 @@ class TractographyBatchScheduler(BatchScheduler):
         self.resample_streamlines = resample_streamlines
         self.sort_streamlines_by_length = sort_streamlines_by_length
         self.feed_previous_direction = feed_previous_direction
-        
+
         # Sort streamlines according to their length by default.
         # This should speed up validation.
         self.indices = np.argsort(self.dataset.streamlines._lengths)
@@ -193,7 +193,7 @@ class TractographyBatchScheduler(BatchScheduler):
         return {}  # No updates
 
     def get_state(self):
-        state = {"version": 4,
+        state = {"version": 5,
                  "batch_size": self.batch_size,
                  "noisy_streamlines_sigma": self.noisy_streamlines_sigma,
                  "use_augment_by_flipping": self.use_augment_by_flipping,

--- a/learn2track/factories.py
+++ b/learn2track/factories.py
@@ -201,7 +201,8 @@ def batch_scheduler_factory(hyperparams, dataset, train_mode=True, batch_size_ov
                                           noisy_streamlines_sigma=hyperparams['noisy_streamlines_sigma'] if train_mode else None,
                                           shuffle_streamlines=train_mode,
                                           resample_streamlines=(not hyperparams['keep_step_size']) and train_mode,
-                                          feed_previous_direction=hyperparams['feed_previous_direction'])
+                                          feed_previous_direction=hyperparams['feed_previous_direction'],
+                                          sort_streamlines_by_length=hyperparams['sort_streamlines'] and train_mode)
 
     elif hyperparams['model'] == 'gru_multistep':
         from learn2track.batch_schedulers import MultistepSequenceBatchScheduler

--- a/scripts/eval_model.py
+++ b/scripts/eval_model.py
@@ -63,7 +63,8 @@ def main():
     # Use this for hyperparams added in a new version, but nonexistent from older versions
     retrocompatibility_defaults = {'feed_previous_direction': False,
                                    'normalize': False,
-                                   'keep_step_size': False}
+                                   'keep_step_size': False,
+                                   'sort_streamlines': False}
     for new_hyperparams, default_value in retrocompatibility_defaults.items():
         if new_hyperparams not in hyperparams:
             hyperparams[new_hyperparams] = default_value

--- a/scripts/learn.py
+++ b/scripts/learn.py
@@ -195,6 +195,8 @@ def build_argparser():
                           help='seed used to generate random numbers in the batch scheduler. Default=1234')
     training.add_argument('--keep-step-size', action="store_true",
                           help='if specified, training streamlines will not be resampled between batches (streamlines will keep their original step size)')
+    training.add_argument('--sort-streamlines', action="store_true",
+                          help='if specified, streamlines will be approximatively regrouped according to their lengths. (Training speedup).')
 
     # Optimizer options
     optimizer = p.add_argument_group("Optimizer (required)")
@@ -275,6 +277,7 @@ def main():
     # Use this for hyperparams added in a new version, but nonexistent from older versions
     retrocompatibility_defaults = {'feed_previous_direction': False,
                                    'normalize': False,
+                                   'sort_streamlines': False,
                                    'keep_step_size': False}
     experiment_path, hyperparams, resuming = utils.maybe_create_experiment_folder(args, exclude=hyperparams_to_exclude,
                                                                                   retrocompatibility_defaults=retrocompatibility_defaults)


### PR DESCRIPTION
Might become handy for HCP data. The streamlines are not completely sorted so there still a bit of randomness in the batches. I agree it is not ideal but let see the impact on the training/validation error. 